### PR TITLE
Remove Watermark from Default Presets

### DIFF
--- a/src/presets.lua
+++ b/src/presets.lua
@@ -35,12 +35,6 @@ return {
         -- Obfuscation steps
         Steps = {
             {
-                Name = "WatermarkCheck";
-                Settings = {
-                    Content = "This Script was obfuscated using the Weak Preset of Prometheus Obfuscator by Levno_710";
-                }
-            },
-            {
                 Name = "Vmify";
                 Settings = {
                     
@@ -74,12 +68,6 @@ return {
         Seed = 0;
         -- Obfuscation steps
         Steps = {
-            {
-                Name = "WatermarkCheck";
-                Settings = {
-                    Content = "This Script was obfuscated using the Medium Preset of Prometheus Obfuscator by Levno_710";
-                }
-            },
             {
                 Name = "EncryptStrings";
                 Settings = {
@@ -135,12 +123,6 @@ return {
         Seed = 0;
         -- Obfuscation steps
         Steps = {
-            {
-                Name = "WatermarkCheck";
-                Settings = {
-                    Content = "This Script was obfuscated using the Strong Preset of Prometheus Obfuscator by Levno_710";
-                }
-            },
             {
                 Name = "Vmify";
                 Settings = {


### PR DESCRIPTION
This PR is done in response to #58.
The Prometheus branded watermark is no longer the default in the presets.
A custom watermark can still be used with a custom config.