### PR TITLE
Make Lua 5.1 accept hex string literals, unicode string literals and \\z string literals as well as binary number literals

### DIFF
--- a/src/prometheus/enums.lua
+++ b/src/prometheus/enums.lua
@@ -36,7 +36,7 @@ Enums.Conventions = {
 		BinaryNumberChars   = {"0", "1"},
 		DecimalExponent     = {"e", "E"},
 		HexadecimalNums     = {"x", "X"},
-		BinaryNums          = false,
+		BinaryNums          = {"b", "B"},,
 		DecimalSeperators   = false,
 		
 		EscapeSequences     = {
@@ -52,9 +52,9 @@ Enums.Conventions = {
 			["\'"] = "\'";
 		},
 		NumericalEscapes = true,
-		EscapeZIgnoreNextWhitespace = false,
-		HexEscapes = false,
-		UnicodeEscapes = false,
+		EscapeZIgnoreNextWhitespace = true,
+		HexEscapes = true,
+		UnicodeEscapes = true,
 	},
 	[Enums.LuaVersion.LuaU] = {
 		Keywords = {


### PR DESCRIPTION
LuaJIT (the Lua 5.1 JIT compiler) supports the afformentioned literal extensions and they are on newer versions of Lua.

This will extend the compatibility between vanilla Lua code and code written in JIT.