### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.lua]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This makes Githubs web IDE use a tab lenght of 4 instead of 8 for readability in the Github web IDE