### PR TITLE
Escape string pattern for `-`

### DIFF
--- a/src/prometheus/util.lua
+++ b/src/prometheus/util.lua
@@ -24,7 +24,7 @@ end
 
 local function escape(str)
 	return str:gsub(".", function(char)
-		if char:match('[^ -~\n\t\a\b\v\r\"\']') then -- Check if non Printable ASCII Character
+		if char:match("[^ %-~\n\t\a\b\v\r\"\']") then -- Check if non Printable ASCII Character
 			return string.format("\\%03d", string.byte(char))
 		end
 		if(char == "\\") then


### PR DESCRIPTION
While it does function inside a character set it's still a good practice to escape it.
![image](https://user-images.githubusercontent.com/68124053/221193732-37665297-3006-44ba-94a4-2f8ec11ccd64.png)
