### PR TITLE
Made IDEs correctly use Unix LF instead of CRLF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
 [*.lua]
 indent_style = tab
 indent_size = 4
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.lua text=auto
+*.lua eol=lf


### PR DESCRIPTION
Some IDEs will use CRLF line endings instead of just a newline (things on Windows)

This fixes it so that they will use the proper LF ie. a single newline instead of a carriage return and a newline