### PR TITLE
fix!: Prevent tampering bypass by changing error handling

### DIFF
--- a/src/prometheus/steps/AntiTamper.lua
+++ b/src/prometheus/steps/AntiTamper.lua
@@ -105,7 +105,7 @@ function AntiTamper:apply(ast, pipeline)
     end
     code = code .. [[
     local gmatch = string.gmatch;
-    local err = function() error("Tamper Detected!") end;
+    local err = function() return print("Tamper Detected!") end;
 
     local pcallIntact2 = false;
     local pcallIntact = pcall(function()


### PR DESCRIPTION
This whole section would've been bypassable by just doing:
``error = function() return end``

* Change to return print