### PR TITLE
Fix an issue with vararg being indexed and add partial support for Luau if/else expressions.

### DIFF
--- a/src/prometheus/ast.lua
+++ b/src/prometheus/ast.lua
@@ -76,6 +76,8 @@ local AstKind = {
 
 	-- Misc
 	NopStatement = "NopStatement";
+
+	IfElseExpression = "IfElseExpression";
 }
 
 local astKindExpressionLookup = {
@@ -141,6 +143,15 @@ end
 function Ast.NopStatement()
 	return {
 		kind = AstKind.NopStatement;
+	}
+end
+
+function Ast.IfElseExpression(condition, true_value, false_value)
+	return {
+		kind = AstKind.IfElseExpression,
+		condition = condition,
+		true_value = true_value,
+		false_value = false_value
 	}
 end
 

--- a/src/prometheus/parser.lua
+++ b/src/prometheus/parser.lua
@@ -928,6 +928,19 @@ function Parser:expressionLiteral(scope)
 		local scope, id = scope:resolve(name);
 		return Ast.VariableExpression(scope, id);
 	end
+
+	-- IfElse
+	if(LuaVersion.LuaU) then
+		if(consume(self, TokenKind.Keyword, "if")) then
+			local condition = self:expression(scope);
+			expect(self, TokenKind.Keyword, "then");
+			local true_value = self:expression(scope);
+			expect(self, TokenKind.Keyword, "else");
+			local false_value = self:expression(scope);
+
+			return Ast.IfElseExpression(condition, true_value, false_value);
+		end
+	end
 	
 	if(self.disableLog) then error() end
 	logger:error(generateError(self, "Unexpected Token \"" .. peek(self).source .. "\". Expected a Expression!"))

--- a/src/prometheus/unparser.lua
+++ b/src/prometheus/unparser.lua
@@ -738,7 +738,7 @@ function Unparser:unparseExpression(expression, tabbing)
 	k = AstKind.IndexExpression;
 	if(expression.kind == k or expression.kind == AstKind.AssignmentIndexing) then
 		local base = self:unparseExpression(expression.base, tabbing);
-		if(Ast.astKindExpressionToNumber(expression.base.kind) > Ast.astKindExpressionToNumber(k)) then
+		if(expression.base.kind == AstKind.VarargExpression or Ast.astKindExpressionToNumber(expression.base.kind) > Ast.astKindExpressionToNumber(k)) then
 			base = "(" .. base .. ")";
 		end
 		
@@ -858,6 +858,21 @@ function Unparser:unparseExpression(expression, tabbing)
 		end
 		
 		return code .. self:optionalWhitespace((p and "," or "") .. self:newline() .. self:tabs(tabbing)) .. "}";
+	end
+
+	if (self.luaVersion == LuaVersion.LuaU) then
+		k = AstKind.IfElseExpression
+		if(expression.kind == k) then
+			code = "if ";
+
+			code = code .. self:unparseExpression(expression.condition);
+			code = code .. " then ";
+			code = code .. self:unparseExpression(expression.true_value);
+			code = code .. " else ";
+			code = code .. self:unparseExpression(expression.false_value);
+
+			return code
+		end
 	end
 
 	logger:error(string.format("\"%s\" is not a valid unparseable expression", expression.kind));

--- a/src/prometheus/visitast.lua
+++ b/src/prometheus/visitast.lua
@@ -235,6 +235,11 @@ function visitExpression(expression, previsit, postvisit, data)
 		expression.base = visitExpression(expression.base, previsit, postvisit, data);
 		expression.index = visitExpression(expression.index, previsit, postvisit, data);
 	end
+	if(expression.kind == AstKind.IfElseExpression) then
+		expression.condition = visitExpression(expression.condition, previsit, postvisit, data);
+		expression.true_expr = visitExpression(expression.true_expr, previsit, postvisit, data);
+		expression.false_expr = visitExpression(expression.false_expr, previsit, postvisit, data);
+	end
 
 	if(type(postvisit) == "function") then
 		expression = postvisit(expression, data) or expression;


### PR DESCRIPTION
This fixes an issue with the following code:
```lua
print((...)[...])
```
which would unparse to
```lua
print(...[...])
```
causing syntax error.

I also added parser support for if/else expressions. There is no compiler support (it should be quite easy to add it) so I won't mention any of the relevant issues yet.