### PR TITLE
style: dont use two requires in same line

### DIFF
--- a/src/prometheus/randomStrings.lua
+++ b/src/prometheus/randomStrings.lua
@@ -1,4 +1,5 @@
-local Ast, utils = require("prometheus.ast"), require("prometheus.util");
+local Ast = require("prometheus.ast")
+local utils = require("prometheus.util")
 local charset = utils.chararray("qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890")
 
 local function randomString(wordsOrLen)


### PR DESCRIPTION
Small styling fix, leaving only one require per line!

Motivation: I created an npm package for Prometheus. I had to make a small patch just to avoid changing my bundler's lexer. If want to follow the project, see: https://www.npmjs.com/package/@gamely/prometheus-cli

closes #192 

https://github.com/gly-engine/prometheus-cli/blob/c029dedf2cfe9ced7b941a4f79a0a9fce29ebec5/scripts/copy.js#L8-L11
