### PR TITLE
Fix invalid usage of debug.getlocal in AntiTamper

### DIFF
--- a/src/prometheus/steps/AntiTamper.lua
+++ b/src/prometheus/steps/AntiTamper.lua
@@ -71,10 +71,6 @@ function AntiTamper:apply(ast, pipeline)
                     valid = false;
                 end
 
-                if debug.getlocal(funcs[i], 1) then
-                    valid = false;
-                end
-
                 if debug.getupvalue(funcs[i], 1) then
                     valid = false;
                 end


### PR DESCRIPTION
Fixes the aggressive anti-tamper mode, which has presumably been broken since 141de77 / #168
`debug.getlocal` expects a level, not a function (see [lua 5.1 docs](https://www.lua.org/manual/5.1/manual.html#pdf-debug.getlocal)), so this call is invalid and will always error