### PR TITLE
Improve playground warnings

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --base /Prometheus/",
     "test": "vitest run",
     "test:e2e": "playwright test"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BookText, Check, Copy, Download, FileCode2, Github, Loader2, Play, RotateCcw, Share2, Square } from "lucide-react"
+import { BookText, Check, Copy, Download, FileCode2, Github, Loader2, Play, RotateCcw, Share2, Square, TriangleAlert } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
@@ -602,6 +602,14 @@ export default function App() {
                 <TooltipContent>Share link</TooltipContent>
               </Tooltip>
             </div>
+            {preset === "Strong" ? (
+              <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-snug text-amber-900 md:col-span-2 xl:col-span-5 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+                <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                <p>
+                  Strong is very strict and only supports Lua 5.1. It will fail in environments such as the web playground runtime (Lua 5.4).
+                </p>
+              </div>
+            ) : null}
           </div>
         </section>
 

--- a/web/src/e2e/app.spec.ts
+++ b/web/src/e2e/app.spec.ts
@@ -34,6 +34,22 @@ test("runs input script and shows logs", async ({ page }) => {
   await expect(page.getByText("Run works")).toBeVisible()
 })
 
+test("shows a strictness warning for the Strong preset", async ({ page }) => {
+  await page.goto("/")
+  await expect(page.getByRole("heading", { name: "Prometheus Playground" })).toBeVisible()
+
+  const warning = page.getByText("Strong is very strict and only supports Lua 5.1. It will fail in environments such as the web playground runtime (Lua 5.4).")
+  await expect(warning).toBeHidden()
+
+  await page.getByRole("combobox").first().click()
+  await page.getByRole("option", { name: "Strong" }).click()
+  await expect(warning).toBeVisible()
+
+  await page.getByRole("combobox").first().click()
+  await page.getByRole("option", { name: "Medium" }).click()
+  await expect(warning).toBeHidden()
+})
+
 test("share link roundtrip keeps the same obfuscated output", async ({ browser, page, context }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"])
   await page.goto("/")

--- a/web/src/worker/prometheusRunner.ts
+++ b/web/src/worker/prometheusRunner.ts
@@ -16,6 +16,14 @@ type LuaFactoryConstructor = new (
 
 let luaFactoryCtorPromise: Promise<LuaFactoryConstructor> | null = null
 
+function resolveWasmUri(wasmUrl: string): string {
+  if (typeof process !== "undefined" && process.versions?.node && wasmUrl.startsWith("/@fs/")) {
+    return wasmUrl.slice("/@fs".length)
+  }
+
+  return wasmUrl
+}
+
 async function getLuaFactoryConstructor(): Promise<LuaFactoryConstructor> {
   if (luaFactoryCtorPromise) {
     return luaFactoryCtorPromise
@@ -174,7 +182,7 @@ export async function runPrometheus(options: PrometheusOptions): Promise<Prometh
     // Force a local Vite-managed Wasm URL so dev/preview behave the same and
     // we don't depend on wasmoon's default CDN URL resolution in workers.
     const LuaFactory = await getLuaFactoryConstructor()
-    lua = await new LuaFactory(glueWasmUrl).createEngine({ openStandardLibs: true })
+    lua = await new LuaFactory(resolveWasmUri(glueWasmUrl)).createEngine({ openStandardLibs: true })
 
     const result = (await lua.doString(buildRunLua(options))) as {
       ok?: unknown
@@ -210,7 +218,7 @@ export async function runLuaScript(
 
   try {
     const LuaFactory = await getLuaFactoryConstructor()
-    lua = await new LuaFactory(glueWasmUrl).createEngine({ openStandardLibs: true })
+    lua = await new LuaFactory(resolveWasmUri(glueWasmUrl)).createEngine({ openStandardLibs: true })
     if (onLog) {
       const luaGlobal = lua.global as unknown as {
         set?: (name: string, value: (...args: unknown[]) => void) => void


### PR DESCRIPTION
Adds a Strong preset warning, fixes preview asset serving, and makes web tests handle Vite wasm paths.